### PR TITLE
Allow for headered ROM

### DIFF
--- a/app/dash.cli.js
+++ b/app/dash.cli.js
@@ -48,17 +48,33 @@ if (!fs.existsSync(vanillaPath)) {
 //-----------------------------------------------------------------
 
 const baseUrl = "https://dashrando.github.io/";
-const vanillaRom = fs.readFileSync(vanillaPath);
+let userRom = fs.readFileSync(vanillaPath);
+let vanillaRom = null;
 const vanillaHash =
    "12b77c4bc9c1832cee8881244659065ee1d84c70c3d29e6eaf92e6798cc2ca72";
+const headeredHash =
+   "9a4441809ac9331cdbc6a50fba1a8fbfd08bc490bc8644587ee84a4d6f924fea"
 
 //-----------------------------------------------------------------
 // Verify the vanilla ROM checksum.
 //-----------------------------------------------------------------
+const verifyAndSetRom = (rom) => {
+   let hash = crypto.createHash("sha256");
+   hash.update(rom);
+   const signature = hash.digest("hex");
+   if (signature === vanillaHash) {
+      return rom
+   } else if (signature === headeredHash) {
+      console.warn('You have entered a headered ROM. The header will now be removed.')
+      const unheaderedContent = rom.slice(512)
+      return verifyAndSetRom(unheaderedContent)
+   }
+   throw Error('Invalid vanilla ROM')
+}
 
-let hash = crypto.createHash("sha256");
-hash.update(vanillaRom);
-if (hash.digest("hex") != vanillaHash) {
+try {
+   vanillaRom = verifyAndSetRom(userRom);
+} catch (e) {
    console.log("Invalid vanilla ROM:", vanillaPath);
    return 1;
 }

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -196,6 +196,40 @@ function ToHexString(byteArray) {
    }).join("");
 }
 
+async function SetVanillaRom(value, inputEl) {
+   let check = await window.crypto.subtle.digest("SHA-256", value);
+   if (
+      ToHexString(new Uint8Array(check)) ==
+      "12b77c4bc9c1832cee8881244659065ee1d84c70c3d29e6eaf92e6798cc2ca72"
+   ) {
+      let randoBtn = document.getElementById("randomize_button");
+      if (randoBtn != null) {
+         randoBtn.disabled = false;
+         randoBtn.style.visibility = "visible";
+      }
+
+      let romBtn = document.getElementById("select-rom");
+      if (romBtn != null) {
+         romBtn.style.opacity = 0.5;
+         romBtn.style.pointerEvents = "none";
+         romBtn.value = "Verified";
+      }
+
+      inputEl.disabled = true;
+      vanillaBytes = new Uint8Array(value);
+   } else if (
+      ToHexString(new Uint8Array(check)) ==
+      "9a4441809ac9331cdbc6a50fba1a8fbfd08bc490bc8644587ee84a4d6f924fea"
+   ) {
+      console.warn('You have entered a headered ROM. The header will now be removed.')
+      const unheaderedContent = value.slice(512)
+      await SetVanillaRom(unheaderedContent, inputEl)
+   } else {
+      alert("Vanilla Rom does not match checksum.");
+      inputEl.value = "";
+   }
+}
+
 function VerifyVanillaRom() {
    let vanillaRomInput = document.getElementById("vanilla-rom");
    let vanillaRom = vanillaRomInput.files[0];
@@ -203,30 +237,7 @@ function VerifyVanillaRom() {
    reader.readAsArrayBuffer(vanillaRom);
 
    reader.onload = async function () {
-      let check = await window.crypto.subtle.digest("SHA-256", reader.result);
-      if (
-         ToHexString(new Uint8Array(check)) ==
-         "12b77c4bc9c1832cee8881244659065ee1d84c70c3d29e6eaf92e6798cc2ca72"
-      ) {
-         let randoBtn = document.getElementById("randomize_button");
-         if (randoBtn != null) {
-            randoBtn.disabled = false;
-            randoBtn.style.visibility = "visible";
-         }
-
-         let romBtn = document.getElementById("select-rom");
-         if (romBtn != null) {
-            romBtn.style.opacity = 0.5;
-            romBtn.style.pointerEvents = "none";
-            romBtn.value = "Verified";
-         }
-
-         vanillaRomInput.disabled = true;
-         vanillaBytes = new Uint8Array(reader.result);
-      } else {
-         alert("Vanilla Rom does not match checksum.");
-         vanillaRomInput.value = "";
-      }
+      await SetVanillaRom(reader.result, vanillaRomInput)
    };
 
    reader.onerror = function () {


### PR DESCRIPTION
Currently the website checks for the SHA256 checksum of the unheadered ROM. This PR detects if the headered ROM is user-selected, and then removes the first 512 bytes (the headered content). This will work in both the CLI and website.