### PR TITLE
Store vanilla ROM locally in browser

### DIFF
--- a/generate.html
+++ b/generate.html
@@ -12,6 +12,8 @@
       <script src="scripts/logic.js"></script>
       <script src="scripts/itemPlacement.js"></script>
       <script src="scripts/generate.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/idb-keyval@6/dist/umd.js"></script>
+      <script src="scripts/storage.js"></script>
       <script src="scripts/modeStandard.js"></script>
       <script src="scripts/modeRecall.js"></script>
       <style>

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -202,21 +202,12 @@ async function SetVanillaRom(value, inputEl) {
       ToHexString(new Uint8Array(check)) ==
       "12b77c4bc9c1832cee8881244659065ee1d84c70c3d29e6eaf92e6798cc2ca72"
    ) {
-      let randoBtn = document.getElementById("randomize_button");
-      if (randoBtn != null) {
-         randoBtn.disabled = false;
-         randoBtn.style.visibility = "visible";
-      }
-
-      let romBtn = document.getElementById("select-rom");
-      if (romBtn != null) {
-         romBtn.style.opacity = 0.5;
-         romBtn.style.pointerEvents = "none";
-         romBtn.value = "Verified";
-      }
-
-      inputEl.disabled = true;
-      vanillaBytes = new Uint8Array(value);
+      const event = new CustomEvent("vanillaRom:input", {
+         detail: {
+            data: new Uint8Array(value),
+         }
+      })
+      document.dispatchEvent(event)
    } else if (
       ToHexString(new Uint8Array(check)) ==
       "9a4441809ac9331cdbc6a50fba1a8fbfd08bc490bc8644587ee84a4d6f924fea"
@@ -229,6 +220,28 @@ async function SetVanillaRom(value, inputEl) {
       inputEl.value = "";
    }
 }
+
+document.addEventListener('vanillaRom:set', (evt) => {
+   let randoBtn = document.getElementById("randomize_button");
+   if (randoBtn != null) {
+      randoBtn.disabled = false;
+   }
+
+   let vanillaRomInput = document.getElementById("vanilla-rom");
+   vanillaRomInput.disabled = true;
+   vanillaBytes = evt.detail.data;
+})
+
+document.addEventListener('vanillaRom:cleared', (evt) => {
+   let randoBtn = document.getElementById("randomize_button");
+   if (randoBtn != null) {
+      randoBtn.disabled = true;
+   }
+
+   let vanillaRomInput = document.getElementById("vanilla-rom");
+   vanillaRomInput.disabled = false;
+   vanillaBytes = null;
+})
 
 function VerifyVanillaRom() {
    let vanillaRomInput = document.getElementById("vanilla-rom");

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -1,0 +1,65 @@
+class VanillaROMStorage {
+  constructor() {
+    if (!this.supported) {
+      console.warn('IndexedDb not supported')
+      return false
+    }
+    const self = this;
+
+    document.addEventListener('vanillaRom:input', async (evt) => {
+      await self.setValue(evt.detail.data)
+    })
+    
+    document.addEventListener('DOMContentLoaded', async () => {
+      try {
+        const data = await idbKeyval.get('vanilla-rom')
+        const valid = await self.verifyData(data)
+        if (!valid) {
+          return self.clearValue()
+        }
+        const dispatchEvt = new CustomEvent('vanillaRom:set', {
+          detail: {
+            data
+          }
+        })
+        document.dispatchEvent(dispatchEvt)
+      } catch (e) {
+        self.clearValue()
+      }
+    })
+  }
+
+  async clearValue() {
+    await idbKeyval.del('vanilla-rom')
+    const dispatchEvt = new CustomEvent('vanillaRom:cleared')
+    document.dispatchEvent(dispatchEvt)
+  }
+
+  async setValue(value) {
+    await idbKeyval.set('vanilla-rom', value)
+    const dispatchEvt = new CustomEvent('vanillaRom:set', {
+      detail: {
+        data: value
+      }
+    })
+    console.log(dispatchEvt)
+    document.dispatchEvent(dispatchEvt)
+  }
+
+  supported() {
+    return ('indexedDB' in window)
+  }
+
+  async verifyData(value) {
+    if (!value) {
+      return false
+    }
+    const signature = await window.crypto.subtle.digest("SHA-256", value);
+    return (
+      ToHexString(new Uint8Array(signature)) ==
+      "12b77c4bc9c1832cee8881244659065ee1d84c70c3d29e6eaf92e6798cc2ca72"
+    )
+  }
+}
+
+new VanillaROMStorage()


### PR DESCRIPTION
When generating a randomized DASH seed, a user currently has to load the vanilla ROM for each seed. This PR captures the user input and stores it via IndexedDB in their browser. This means the user only needs to enter the vanilla ROM once, and then very rarely afterwards.

This means that the vanilla ROM is now available site-wide for other operations. To ensure consistency and correctness, the data stored is verified when loading it every time.