### PR TITLE
Use cleanUrls for Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": true
+}


### PR DESCRIPTION
This PR uses a `vercel.json` file to strip the `.html` extension from serving the HTML file. This should redirect in case a user still uses the `.html` extension.
[Documentation on Vercel's website](https://vercel.com/docs/concepts/projects/project-configuration#cleanurls)

This also forwards the query string parameter if present.
**Example**:
`dashrando.net/seed.html?seed=1&mode=rm` becomes `dashrando.net/seed?seed=1&mode=rm`

## Preview
https://dash-kupppo.vercel.app/
https://dash-kupppo.vercel.app/index.html => https://dash-kupppo.vercel.app/
https://dash-kupppo.vercel.app/generate.html => https://dash-kupppo.vercel.app/generate