### PR TITLE
Site responsiveness

### DIFF
--- a/public/dash.css
+++ b/public/dash.css
@@ -13,6 +13,11 @@ body {
    padding: 0;
 }
 
+ul {
+   margin: 1em 0;
+   padding: 0 0 0 40px;
+}
+
 #wrapper {
    width: 100%;
    max-width: 800px;

--- a/public/dash.css
+++ b/public/dash.css
@@ -4,6 +4,13 @@ body {
    background-color: black;
    color: rgb(210, 210, 210);
 }
+
+#wrapper {
+   width: 100%;
+   max-width: 800px;
+   margin: 0;
+}
+
 a {
    text-decoration: none;
    color: rgb(90, 173, 54);

--- a/public/dash.css
+++ b/public/dash.css
@@ -25,9 +25,10 @@ a {
 }
 #topic_header_grid {
    width: 90%;
-   display: grid;
-   grid-template-columns: 130px auto;
-   grid-template-rows: 130px;
+   display: flex;
+   justify-content: flex-start;
+   align-items: center;
+   gap: 20px;
 }
 #header_img {
    grid-row: 1;
@@ -35,19 +36,17 @@ a {
 }
 .header_text {
    position: relative;
-   bottom: -48px;
+   /* bottom: -48px; */
    text-align: left;
    font-size: 22px;
    text-decoration: underline;
    text-decoration-color: rgb(90, 173, 54);
-   grid-row: 1;
-   grid-column: 2;
-   min-width: 500px;
    z-index: -1;
+   margin-bottom: 20px;
 }
-#header_double_text {
+/* #header_double_text {
    bottom: -28px;
-}
+} */
 #header img {
    max-width: 420px;
    max-height: 160px;

--- a/public/dash.css
+++ b/public/dash.css
@@ -193,7 +193,8 @@ hr {
    }
 
    .damage-table tbody tr {
-      display: block;
+      display: flex;
+      flex-direction: column;
       width: 100%;
       margin-bottom: 20px;
    }
@@ -208,10 +209,10 @@ hr {
       border-bottom: 0;
    }
 
-   /* .damage-table tbody tr td:first-child::before {
+   .damage-table tbody tr td:first-child::before {
       content: '';
       display: none;
-   } */
+   }
 
    .damage-table tbody tr td::before {
       content: attr(data-label);

--- a/public/dash.css
+++ b/public/dash.css
@@ -140,6 +140,11 @@ hr {
 
 .damage-table {
    border: 0;
+   border-collapse: collapse;
+   table-layout: fixed;
+   width: 100%;
+   margin: 0;
+   padding: 0;
 }
 
 .damage-table tbody td {

--- a/public/dash.css
+++ b/public/dash.css
@@ -230,4 +230,16 @@ hr {
    .header_text {
       min-width: unset;
    }
+
+   #topic img {
+      display: block;
+      max-width: 100%;
+      height: auto;
+   }
+
+   #section_label a {
+      display: block;
+      margin: 4px 0;
+      font-size: 0.8em;
+   }
 }

--- a/public/dash.css
+++ b/public/dash.css
@@ -195,6 +195,7 @@ hr {
 
    .damage-table tbody tr td {
       display: block;
+      width: 100%;
       border-bottom: 1px solid #333;
    }
 

--- a/public/dash.css
+++ b/public/dash.css
@@ -1,14 +1,22 @@
 @import url('https://fonts.googleapis.com/css2?family=Mulish:wght@400;700&display=swap');
+* {
+   box-sizing: border-box;
+   padding: 0;
+   margin: 0;
+ }
+
 body {
    font-family: "Mulish", sans-serif;
    background-color: black;
    color: rgb(210, 210, 210);
+   margin: 0;
+   padding: 0;
 }
 
 #wrapper {
    width: 100%;
    max-width: 800px;
-   margin: 0;
+   padding: 8px;
 }
 
 a {
@@ -41,8 +49,10 @@ a {
    bottom: -28px;
 }
 #header img {
-   width: 420px;
-   height: 160px;
+   max-width: 420px;
+   max-height: 160px;
+   width: 100%;
+   display: block;
    opacity: 0.8;
    margin-bottom: 10px;
 }
@@ -137,10 +147,6 @@ hr {
    padding: 4px 8px;
 }
 
-/* .damage-table tbody td:first-child {
-   padding-left: 0;
-} */
-
 .damage-table thead th {
    font-weight: 700;
    text-align: left;
@@ -148,10 +154,73 @@ hr {
    border-bottom: 1px solid #777;
 }
 
-/* .damage-table thead th:first-child {
-   padding-left: 0;
+/* .damage-table thead tr th:nth-child(3),
+.damage-table tbody tr td:nth-child(3) {
+   display: none;
 } */
 
-.damage-table tbody tr:nth-child(even) {
-   background-color: #222;
+@media screen and (min-width: 601px) {
+   .damage-table tbody tr:nth-child(even) {
+      background-color: #222;
+   }
+}
+
+@media screen and (max-width: 600px) {
+   .damage-table {
+      display: block;
+      width: 100%;
+   }
+
+   .damage-table tbody {
+      display: block;
+      width: 90%;
+   }
+
+   .damage-table thead {
+      border: none;
+      clip: rect(0 0 0 0);
+      height: 1px;
+      margin: -1px;
+      overflow: hidden;
+      padding: 0;
+      position: absolute;
+      width: 1px;
+   }
+
+   .damage-table tbody tr {
+      display: block;
+      width: 100%;
+      margin-bottom: 20px;
+   }
+
+   .damage-table tbody tr td {
+      display: block;
+      border-bottom: 1px solid #333;
+   }
+
+   .damage-table tbody tr td:last-child {
+      border-bottom: 0;
+   }
+
+   .damage-table tbody tr td:first-child::before {
+      content: '';
+      display: none;
+   }
+
+   .damage-table tbody tr td::before {
+      content: attr(data-label);
+      display: inline-block;
+      width: 120px;
+      padding-right: 20px;
+      color: #777;
+   }
+
+   .damage-table tbody tr td:first-child {
+      border-bottom: 1px solid #777;
+      font-weight: 700;
+   }
+
+   .header_text {
+      min-width: unset;
+   }
 }

--- a/public/dash.css
+++ b/public/dash.css
@@ -1,6 +1,6 @@
-@import url("https://fonts.googleapis.com/css?family=Muli");
+@import url('https://fonts.googleapis.com/css2?family=Mulish:wght@400;700&display=swap');
 body {
-   font-family: "Muli";
+   font-family: "Mulish", sans-serif;
    background-color: black;
    color: rgb(210, 210, 210);
 }
@@ -119,4 +119,32 @@ hr {
 
 #permalink-container.visible {
    visibility: visible;
+}
+
+.damage-table {
+   border: 0;
+}
+
+.damage-table tbody td {
+   border: 0;
+   padding: 4px 8px;
+}
+
+/* .damage-table tbody td:first-child {
+   padding-left: 0;
+} */
+
+.damage-table thead th {
+   font-weight: 700;
+   text-align: left;
+   padding: 8px;
+   border-bottom: 1px solid #777;
+}
+
+/* .damage-table thead th:first-child {
+   padding-left: 0;
+} */
+
+.damage-table tbody tr:nth-child(even) {
+   background-color: #222;
 }

--- a/public/dash.css
+++ b/public/dash.css
@@ -13,8 +13,12 @@ body {
    padding: 0;
 }
 
-ul {
+ul, ol {
    margin: 1em 0;
+   padding: 0 0 0 20px;
+}
+
+#topic table ul {
    padding: 0 0 0 40px;
 }
 

--- a/public/dash.css
+++ b/public/dash.css
@@ -1,170 +1,175 @@
-@import url('https://fonts.googleapis.com/css2?family=Mulish:wght@400;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Mulish:wght@400;700&display=swap");
 * {
-   box-sizing: border-box;
-   padding: 0;
-   margin: 0;
- }
-
-body {
-   font-family: "Mulish", sans-serif;
-   background-color: black;
-   color: rgb(210, 210, 210);
-   margin: 0;
-   padding: 0;
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
 }
 
-ul, ol {
-   margin: 1em 0;
-   padding: 0 0 0 20px;
+body {
+  font-family: "Mulish", sans-serif;
+  background-color: black;
+  color: rgb(210, 210, 210);
+  margin: 0;
+  padding: 0;
+}
+
+ul,
+ol {
+  margin: 1em 0;
+  padding: 0 0 0 20px;
 }
 
 #topic table ul {
-   padding: 0 0 0 40px;
+  padding: 0 0 0 40px;
 }
 
 #wrapper {
-   width: 100%;
-   max-width: 800px;
-   padding: 8px;
+  width: 100%;
+  max-width: 800px;
+  padding: 8px;
 }
 
 a {
-   text-decoration: none;
-   color: rgb(90, 173, 54);
+  text-decoration: none;
+  color: rgb(90, 173, 54);
 }
 #topic_header_grid {
-   width: 90%;
-   display: flex;
-   justify-content: flex-start;
-   align-items: center;
-   gap: 20px;
+  width: 90%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 20px;
 }
 #header_img {
-   grid-row: 1;
-   grid-column: 1;
+  grid-row: 1;
+  grid-column: 1;
 }
 .header_text {
-   position: relative;
-   /* bottom: -48px; */
-   text-align: left;
-   font-size: 22px;
-   text-decoration: underline;
-   text-decoration-color: rgb(90, 173, 54);
-   z-index: -1;
-   margin-bottom: 20px;
+  position: relative;
+  /* bottom: -48px; */
+  text-align: left;
+  font-size: 22px;
+  text-decoration: underline;
+  text-decoration-color: rgb(90, 173, 54);
+  z-index: -1;
+  margin-bottom: 20px;
 }
 /* #header_double_text {
    bottom: -28px;
 } */
 #header img {
-   max-width: 420px;
-   max-height: 160px;
-   width: 100%;
-   display: block;
-   opacity: 0.8;
-   margin-bottom: 10px;
+  max-width: 420px;
+  max-height: 160px;
+  width: 100%;
+  display: block;
+  opacity: 0.8;
+  margin-bottom: 10px;
 }
 #main_header {
-   font-size: 32px;
-   padding-bottom: 10px;
-   font-weight: bold;
+  font-size: 32px;
+  padding-bottom: 10px;
+  font-weight: bold;
 }
 #download {
-   font-size: 26px;
-   padding-bottom: 14px;
-   font-weight: bold;
+  font-size: 26px;
+  padding-bottom: 14px;
+  font-weight: bold;
 }
 #dash_links {
-   font-size: 22px;
-   padding-bottom: 10px;
-   font-weight: bold;
-   font-variant: small-caps;
+  font-size: 22px;
+  padding-bottom: 10px;
+  font-weight: bold;
+  font-variant: small-caps;
 }
 #schedule_notice {
-   font-size: 20px;
-   padding-top: 20px;
-   padding-bottom: 20px;
-   font-weight: bold;
-   font-style: italic;
-   color: rgb(90, 173, 54);
+  font-size: 20px;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  font-weight: bold;
+  font-style: italic;
+  color: rgb(90, 173, 54);
 }
 .dash_source {
-   padding-left: 30px;
+  padding-left: 30px;
 }
 #topic {
-   font-size: 16px;
-   width: 90%;
+  font-size: 16px;
+  width: 90%;
 }
 hr {
-   border: 1px solid rgb(90, 173, 54);
-   width: 92%;
-   text-align: left;
-   margin-left: 0px;
+  border: 1px solid rgb(90, 173, 54);
+  width: 92%;
+  text-align: left;
+  margin-left: 0px;
 }
 .utility {
-   background-color: rgb(0, 255, 255);
-   color: black;
+  background-color: rgb(0, 255, 255);
+  color: black;
 }
 .utility_inverse {
-   background-color: black;
-   color: rgb(0, 255, 255);
+  background-color: black;
+  color: rgb(0, 255, 255);
 }
 .suits {
-   background-color: yellow;
-   color: black;
+  background-color: yellow;
+  color: black;
 }
 .suits_inverse {
-   color: yellow;
-   background-color: black;
+  color: yellow;
+  background-color: black;
 }
 .placement {
-   background-color: rgb(0, 255, 0);
-   color: black;
+  background-color: rgb(0, 255, 0);
+  color: black;
+}
+.challenge {
+  color: rgb(0, 255, 0);
+  background-color: black;
 }
 .misc {
-   background-color: rgb(209, 46, 187);
-   color: black;
+  background-color: rgb(209, 46, 187);
+  color: black;
 }
 .misc_inverse {
-   color: rgb(209, 46, 187);
-   background-color: black;
+  color: rgb(209, 46, 187);
+  background-color: black;
 }
 
 .dash_changes {
-   background-color: rgba(255, 0, 0, 0.45);
+  background-color: rgba(255, 0, 0, 0.45);
 }
 
 #seed-permalink {
-   display: block;
+  display: block;
 }
 
 #permalink-container {
-   visibility: hidden;
+  visibility: hidden;
 }
 
 #permalink-container.visible {
-   visibility: visible;
+  visibility: visible;
 }
 
 .damage-table {
-   border: 0;
-   border-collapse: collapse;
-   table-layout: fixed;
-   width: 100%;
-   margin: 0;
-   padding: 0;
+  border: 0;
+  border-collapse: collapse;
+  table-layout: fixed;
+  width: 100%;
+  margin: 0;
+  padding: 0;
 }
 
 .damage-table tbody td {
-   border: 0;
-   padding: 4px 8px;
+  border: 0;
+  padding: 4px 8px;
 }
 
 .damage-table thead th {
-   font-weight: 700;
-   text-align: left;
-   padding: 8px;
-   border-bottom: 1px solid #777;
+  font-weight: 700;
+  text-align: left;
+  padding: 8px;
+  border-bottom: 1px solid #777;
 }
 
 /* .damage-table thead tr th:nth-child(3),
@@ -173,81 +178,81 @@ hr {
 } */
 
 @media screen and (min-width: 601px) {
-   .damage-table tbody tr:nth-child(even) {
-      background-color: #222;
-   }
+  .damage-table tbody tr:nth-child(even) {
+    background-color: #222;
+  }
 }
 
 @media screen and (max-width: 600px) {
-   .damage-table {
-      display: block;
-      width: 100%;
-   }
+  .damage-table {
+    display: block;
+    width: 100%;
+  }
 
-   .damage-table tbody {
-      display: block;
-      width: 90%;
-   }
+  .damage-table tbody {
+    display: block;
+    width: 90%;
+  }
 
-   .damage-table thead {
-      border: none;
-      clip: rect(0 0 0 0);
-      height: 1px;
-      margin: -1px;
-      overflow: hidden;
-      padding: 0;
-      position: absolute;
-      width: 1px;
-   }
+  .damage-table thead {
+    border: none;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+  }
 
-   .damage-table tbody tr {
-      display: flex;
-      flex-direction: column;
-      width: 100%;
-      margin-bottom: 20px;
-   }
+  .damage-table tbody tr {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    margin-bottom: 20px;
+  }
 
-   .damage-table tbody tr td {
-      display: block;
-      width: 100%;
-      border-bottom: 1px solid #333;
-   }
+  .damage-table tbody tr td {
+    display: block;
+    width: 100%;
+    border-bottom: 1px solid #333;
+  }
 
-   .damage-table tbody tr td:last-child {
-      border-bottom: 0;
-   }
+  .damage-table tbody tr td:last-child {
+    border-bottom: 0;
+  }
 
-   .damage-table tbody tr td:first-child::before {
-      content: '';
-      display: none;
-   }
+  .damage-table tbody tr td:first-child::before {
+    content: "";
+    display: none;
+  }
 
-   .damage-table tbody tr td::before {
-      content: attr(data-label);
-      display: inline-block;
-      width: 120px;
-      padding-right: 20px;
-      color: #777;
-   }
+  .damage-table tbody tr td::before {
+    content: attr(data-label);
+    display: inline-block;
+    width: 120px;
+    padding-right: 20px;
+    color: #777;
+  }
 
-   .damage-table tbody tr td:first-child {
-      border-bottom: 1px solid #777;
-      font-weight: 700;
-   }
+  .damage-table tbody tr td:first-child {
+    border-bottom: 1px solid #777;
+    font-weight: 700;
+  }
 
-   .header_text {
-      min-width: unset;
-   }
+  .header_text {
+    min-width: unset;
+  }
 
-   #topic img {
-      display: block;
-      max-width: 100%;
-      height: auto;
-   }
+  #topic img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
 
-   #section_label a {
-      display: block;
-      margin: 4px 0;
-      font-size: 0.8em;
-   }
+  #section_label a {
+    display: block;
+    margin: 4px 0;
+    font-size: 0.8em;
+  }
 }

--- a/public/dash.css
+++ b/public/dash.css
@@ -208,10 +208,10 @@ hr {
       border-bottom: 0;
    }
 
-   .damage-table tbody tr td:first-child::before {
+   /* .damage-table tbody tr td:first-child::before {
       content: '';
       display: none;
-   }
+   } */
 
    .damage-table tbody tr td::before {
       content: attr(data-label);

--- a/public/generate.html
+++ b/public/generate.html
@@ -42,7 +42,7 @@
          input,
          button,
          select {
-            font-family: "Muli";
+            font-family: "Mulish";
             font-size: 14px;
          }
          #fixed_value {

--- a/public/generate.html
+++ b/public/generate.html
@@ -70,6 +70,7 @@
       <link rel="stylesheet" type="text/css" href="dash.css" />
    </head>
    <body>
+      <div id="wrapper">
       <div id="header">
          <a href="/"
             ><img
@@ -203,5 +204,6 @@
       <div id="permalink-container">
          <p>Your Seed's URL: <span id="seed-permalink">&nbsp;</span></p>
       </div>
+   </div>
    </body>
 </html>

--- a/public/generate.html
+++ b/public/generate.html
@@ -1,6 +1,7 @@
-<html>
+<html lang="en">
    <head>
       <title>Generate DASH Seed</title>
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       <script src="/generate.bundled.js"></script>
       <style>
          #rom_load {

--- a/public/index.html
+++ b/public/index.html
@@ -181,11 +181,11 @@
                </table>
             </li>
             <li>
-               36 Item Locations: +3 Charge Upgrades, +3 New Items, -2 ETanks,
-               -2 Reserves
+               36 Item Locations
                <span class="misc_inverse">(Map Balance)</span>
             </li>
             <ul type="disc">
+               <li>Item Pool: +3 Charge Upgrades, +3 New Items, -2 ETanks, -2 Reserves</li>
                <li>Kraid Etank removed from Major Item Location pool</li>
                <li>Sky Missile added to Major Item Location pool</li>
                <li>Watering Hole Missile added to Major Item Location pool</li>
@@ -202,14 +202,27 @@
                </ul>
             </li>
             <li>
+               Rebalanced Forgotten Highway
+               <span class="misc_inverse">(Map Balance)</span>
+               <ul type="disc">
+                  <li>Gray door to Cac Alley is now a blue door (recent change based on player feedback)</li>
+                  <li>
+                     WS etank location can now be collected before defeating Phantoon if you enter the WS location from the Forgotten Highway side. The door from WS shaft to Sponge Bath remains locked until Phantoon is defeated.
+                  </li>
+                  <li>
+                     Orange door at Forgotten Highway elevator is now blue on both sides
+                  </li>
+               </ul>
+            </li>
+            <li>
                Rebalanced Plasma Location
                <span class="misc_inverse">(Map Balance)</span>
                <ul type="disc">
                   <li>Plasma Gray door is now a blue door</li>
                   <li>Replaced pink pirates with green pirates</li>
                   <li>
-                     Added a platform in the middle of the plasma room that
-                     allows exit from the room without “can fly”
+                     Added platform in Plasma room that
+                     allows exit without “can fly”
                   </li>
                </ul>
             </li>
@@ -218,7 +231,7 @@
                <span class="misc_inverse">(Map Balance)</span>
                <ul type="disc">
                   <li>
-                     Removed all 5 of the ceiling blocks from the pants room before Shaktool (the grapple block and the other 4 blocks on that "row")
+                     Removed all ceiling blocks from the pants room before Shaktool (grapple block and the adjacent blocks)
                   </li>
                   <li>Removed the sand from the Shaktool</li>
                </ul>
@@ -230,7 +243,6 @@
                  <li>Removed green gate from Crocomire's Lair (Above Grapple)</li>
                </ul>
             </li>
-            <li>Gray door to Cac Alley is now a blue door (recent change based on player feedback)</li>
             <li>
                Pressure Valve <span class="utility_inverse">(New Item)</span>
                <ul type="disc">
@@ -266,8 +278,7 @@
                <span class="utility_inverse">(New Item)</span>
                <ul type="disc">
                   <li>
-                     Like Space Jump but only one extra spin jump instead of
-                     infinite
+                     Works like Space Jump but gives only one extra spin jump 
                   </li>
                </ul>
             </li>
@@ -283,19 +294,20 @@
                </ul>
             </li>
             <li>
-               WS save station is now usable at all times
+               Common Map Updates
+               <span class="misc_inverse">(Map Balance)</span>
+               <ul>
+                  <li>
+                     WS save station is now usable at all times
+                  </li>
+                  <li>
+                     The door to enter Croc's lair is now blue on both sides
+                  </li>
+               </ul>
             </li>
             <li>
-               WS etank location can now be collected before defeating Phantoon if you enter the WS location from the Forgotten Highway side. The door from WS shaft to Sponge Bath remains locked until Phantoon is defeated.
-            </li>
-            <li>
-               The orange door at the Forgotten Highway elevator is now blue on both sides
-            </li>
-            <li>
-               The door to enter Croc's lair is now blue on both sides
-            </li>
-            <li>
-               Ending sequence has been changed
+               Ending Sequence Criteria
+               <span class="challenge">(Challenge)</span>
                <ul type="disc">
                   <li>
                      Less than 45 minutes = Best ending
@@ -380,7 +392,7 @@
                         <span style="text-decoration: underline"
                            >Minor Item Ratio</span
                         ><br />
-                        <div style="margin-left: 16px">
+                        <div style="margin-left: 4px">
                            Super Missiles: 15 &#177; 3<br />
                            Power Bombs: 17 &#177; 3<br />
                            Missiles: All remaining items (average of 34)
@@ -390,7 +402,7 @@
                         <span style="text-decoration: underline"
                            >Green Brinstar Logical Progression Item</span
                         ><br />
-                        <div style="margin-left: 16px">
+                        <div style="margin-left: 4px">
                            Power Bombs: 46.1%<br />
                            Bombs: 30.8%<br />
                            Screw Attack: 15.4%<br />
@@ -433,6 +445,7 @@
          >
          were prepared by <a href="https://www.twitch.tv/Kipp">Kipp</a> to
          outline the major changes featured in DASH.
+         <br /><br />
       </div>
       <hr />
       <br />

--- a/public/index.html
+++ b/public/index.html
@@ -133,7 +133,7 @@
                         <td data-label="Charge x4">250</td>
                      </tr>
                      <tr>
-                        <td>Wave</td>
+                        <td>Ice + Spazer</td>
                         <td data-label="Beam Damage">50</td>
                         <td data-label="Starter Charge">50</td>
                         <td data-label="Charge x1">100</td>

--- a/public/index.html
+++ b/public/index.html
@@ -1,8 +1,9 @@
-<html>
+<html lang="en">
    <head>
       <title>Super Metroid DASH Randomizer</title>
-      <link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
-      <link rel="stylesheet" type="text/css" href="dash.css" />
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
+      <link rel="stylesheet" type="text/css" href="/dash.css" />
       <style>
          table,
          td {
@@ -45,7 +46,7 @@
       <div id="header">
          <a href="/"
             ><img
-               src="images/dashLogo-noBG.png"
+               src="/images/dashLogo-noBG.png"
                alt="Super Metroid DASH Randomizer"
          /></a>
          <div id="main_header">Super Metroid DASH Randomizer!</div>
@@ -82,10 +83,6 @@
                   <li>4 Individual Charge Upgrades added to Major Item pool</li>
                </ul>
                <br />
-               <!-- <img
-                  src="images/recall_beam_damage_table.png"
-                  class="beam_table"
-               /> -->
                <table class="damage-table" cellpadding="0" cellspacing="0">
                   <thead>
                      <tr>

--- a/public/index.html
+++ b/public/index.html
@@ -81,10 +81,106 @@
                   <li>4 Individual Charge Upgrades added to Major Item pool</li>
                </ul>
                <br />
-               <img
+               <!-- <img
                   src="images/recall_beam_damage_table.png"
                   class="beam_table"
-               />
+               /> -->
+               <table class="damage-table" cellpadding="0" cellspacing="0">
+                  <thead>
+                     <tr>
+                        <th>DASH Combo</th>
+                        <th>Beam Damage</th>
+                        <th>Starter Charge</th>
+                        <th>Charge x1</th>
+                        <th>Charge x2</th>
+                        <th>Charge x3</th>
+                        <th>Charge x4</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td>Power</td>
+                        <td>20</td>
+                        <td>20</td>
+                        <td>40</td>
+                        <td>60</td>
+                        <td>80</td>
+                        <td>100</td>
+                     </tr>
+                     <tr>
+                        <td>Ice</td>
+                        <td>30</td>
+                        <td>30</td>
+                        <td>60</td>
+                        <td>90</td>
+                        <td>120</td>
+                        <td>150</td>
+                     </tr>
+                     <tr>
+                        <td>Spazer</td>
+                        <td>40</td>
+                        <td>40</td>
+                        <td>80</td>
+                        <td>120</td>
+                        <td>160</td>
+                        <td>200</td>
+                     </tr>
+                     <tr>
+                        <td>Wave</td>
+                        <td>50</td>
+                        <td>50</td>
+                        <td>100</td>
+                        <td>150</td>
+                        <td>200</td>
+                        <td>250</td>
+                     </tr>
+                     <tr>
+                        <td>Wave</td>
+                        <td>50</td>
+                        <td>50</td>
+                        <td>100</td>
+                        <td>150</td>
+                        <td>200</td>
+                        <td>250</td>
+                     </tr>
+                     <tr>
+                        <td>Ice + Wave</td>
+                        <td>60</td>
+                        <td>60</td>
+                        <td>120</td>
+                        <td>180</td>
+                        <td>240</td>
+                        <td>300</td>
+                     </tr>
+                     <tr>
+                        <td>Wave + Spazer</td>
+                        <td>80</td>
+                        <td>80</td>
+                        <td>180</td>
+                        <td>250</td>
+                        <td>360</td>
+                        <td>450</td>
+                     </tr>
+                     <tr>
+                        <td>IWS (New Route)</td>
+                        <td>100</td>
+                        <td>100</td>
+                        <td>200</td>
+                        <td>300</td>
+                        <td>400</td>
+                        <td>500</td>
+                     </tr>
+                     <tr>
+                        <td>Plasma</td>
+                        <td>100</td>
+                        <td>100</td>
+                        <td>200</td>
+                        <td>300</td>
+                        <td>400</td>
+                        <td>500</td>
+                     </tr>
+                  </tbody>
+               </table>
             </li>
             <li>
                36 Item Locations: +3 Charge Upgrades, +3 New Items, -2 ETanks,

--- a/public/index.html
+++ b/public/index.html
@@ -98,84 +98,84 @@
                   <tbody>
                      <tr>
                         <td>Power</td>
-                        <td>20</td>
-                        <td>20</td>
-                        <td>40</td>
-                        <td>60</td>
-                        <td>80</td>
-                        <td>100</td>
+                        <td data-label="Beam Damage">20</td>
+                        <td data-label="Starter Charge">20</td>
+                        <td data-label="Charge x1">40</td>
+                        <td data-label="Charge x2">60</td>
+                        <td data-label="Charge x3">80</td>
+                        <td data-label="Charge x4">100</td>
                      </tr>
                      <tr>
                         <td>Ice</td>
-                        <td>30</td>
-                        <td>30</td>
-                        <td>60</td>
-                        <td>90</td>
-                        <td>120</td>
-                        <td>150</td>
+                        <td data-label="Beam Damage">30</td>
+                        <td data-label="Starter Charge">30</td>
+                        <td data-label="Charge x1">60</td>
+                        <td data-label="Charge x2">90</td>
+                        <td data-label="Charge x3">120</td>
+                        <td data-label="Charge x4">150</td>
                      </tr>
                      <tr>
                         <td>Spazer</td>
-                        <td>40</td>
-                        <td>40</td>
-                        <td>80</td>
-                        <td>120</td>
-                        <td>160</td>
-                        <td>200</td>
+                        <td data-label="Beam Damage">40</td>
+                        <td data-label="Starter Charge">40</td>
+                        <td data-label="Charge x1">80</td>
+                        <td data-label="Charge x2">120</td>
+                        <td data-label="Charge x3">160</td>
+                        <td data-label="Charge x4">200</td>
                      </tr>
                      <tr>
                         <td>Wave</td>
-                        <td>50</td>
-                        <td>50</td>
-                        <td>100</td>
-                        <td>150</td>
-                        <td>200</td>
-                        <td>250</td>
+                        <td data-label="Beam Damage">50</td>
+                        <td data-label="Starter Charge">50</td>
+                        <td data-label="Charge x1">100</td>
+                        <td data-label="Charge x2">150</td>
+                        <td data-label="Charge x3">200</td>
+                        <td data-label="Charge x4">250</td>
                      </tr>
                      <tr>
                         <td>Wave</td>
-                        <td>50</td>
-                        <td>50</td>
-                        <td>100</td>
-                        <td>150</td>
-                        <td>200</td>
-                        <td>250</td>
+                        <td data-label="Beam Damage">50</td>
+                        <td data-label="Starter Charge">50</td>
+                        <td data-label="Charge x1">100</td>
+                        <td data-label="Charge x2">150</td>
+                        <td data-label="Charge x3">200</td>
+                        <td data-label="Charge x4">250</td>
                      </tr>
                      <tr>
                         <td>Ice + Wave</td>
-                        <td>60</td>
-                        <td>60</td>
-                        <td>120</td>
-                        <td>180</td>
-                        <td>240</td>
-                        <td>300</td>
+                        <td data-label="Beam Damage">60</td>
+                        <td data-label="Starter Charge">60</td>
+                        <td data-label="Charge x1">120</td>
+                        <td data-label="Charge x2">180</td>
+                        <td data-label="Charge x3">240</td>
+                        <td data-label="Charge x4">300</td>
                      </tr>
                      <tr>
                         <td>Wave + Spazer</td>
-                        <td>80</td>
-                        <td>80</td>
-                        <td>180</td>
-                        <td>250</td>
-                        <td>360</td>
-                        <td>450</td>
+                        <td data-label="Beam Damage">80</td>
+                        <td data-label="Starter Charge">80</td>
+                        <td data-label="Charge x1">180</td>
+                        <td data-label="Charge x2">250</td>
+                        <td data-label="Charge x3">360</td>
+                        <td data-label="Charge x4">450</td>
                      </tr>
                      <tr>
                         <td>IWS (New Route)</td>
-                        <td>100</td>
-                        <td>100</td>
-                        <td>200</td>
-                        <td>300</td>
-                        <td>400</td>
-                        <td>500</td>
+                        <td data-label="Beam Damage">100</td>
+                        <td data-label="Starter Charge">100</td>
+                        <td data-label="Charge x1">200</td>
+                        <td data-label="Charge x2">300</td>
+                        <td data-label="Charge x3">400</td>
+                        <td data-label="Charge x4">500</td>
                      </tr>
                      <tr>
                         <td>Plasma</td>
-                        <td>100</td>
-                        <td>100</td>
-                        <td>200</td>
-                        <td>300</td>
-                        <td>400</td>
-                        <td>500</td>
+                        <td data-label="Beam Damage">100</td>
+                        <td data-label="Starter Charge">100</td>
+                        <td data-label="Charge x1">200</td>
+                        <td data-label="Charge x2">300</td>
+                        <td data-label="Charge x3">400</td>
+                        <td data-label="Charge x4">500</td>
                      </tr>
                   </tbody>
                </table>

--- a/public/index.html
+++ b/public/index.html
@@ -41,6 +41,7 @@
       </style>
    </head>
    <body>
+      <div id="wrapper">
       <div id="header">
          <a href="/"
             ><img
@@ -516,5 +517,6 @@
          >
          <br /><br />
       </div>
+   </div>
    </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -86,13 +86,13 @@
                <table class="damage-table" cellpadding="0" cellspacing="0">
                   <thead>
                      <tr>
-                        <th>DASH Combo</th>
-                        <th>Beam Damage</th>
-                        <th>Starter Charge</th>
-                        <th>Charge x1</th>
-                        <th>Charge x2</th>
-                        <th>Charge x3</th>
-                        <th>Charge x4</th>
+                        <th scope="col">DASH Combo</th>
+                        <th scope="col">Beam Damage</th>
+                        <th scope="col">Starter Charge</th>
+                        <th scope="col">Charge x1</th>
+                        <th scope="col">Charge x2</th>
+                        <th scope="col">Charge x3</th>
+                        <th scope="col">Charge x4</th>
                      </tr>
                   </thead>
                   <tbody>

--- a/public/readable-logic.html
+++ b/public/readable-logic.html
@@ -14,7 +14,7 @@
          input,
          button,
          select {
-            font-family: "Muli";
+            font-family: "Mulish";
             font-size: 14px;
          }
          #select_logic_dropdown {

--- a/public/readable-logic.html
+++ b/public/readable-logic.html
@@ -80,6 +80,7 @@
       <link rel="stylesheet" type="text/css" href="/dash.css" />
    </head>
    <body>
+      <div id="wrapper">
       <div id="header">
          <a href="/"
             ><img
@@ -101,5 +102,6 @@
       <hr />
       <br />
       <br />
+      </div>
    </body>
 </html>

--- a/public/readable-logic.html
+++ b/public/readable-logic.html
@@ -1,6 +1,7 @@
-<html>
+<html lang="en">
    <head>
       <title>Readable Logic</title>
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       <script src="/logic.bundled.js"></script>
       <style>
          #logic_title {

--- a/public/resources.html
+++ b/public/resources.html
@@ -16,6 +16,7 @@
       <link rel="stylesheet" type="text/css" href="dash.css" />
    </head>
    <body>
+      <div id="wrapper">
       <div id="header">
          <a href="/"
             ><img
@@ -109,5 +110,6 @@
       <hr />
       <br />
       <br />-->
+   </div>
    </body>
 </html>

--- a/public/resources.html
+++ b/public/resources.html
@@ -1,5 +1,6 @@
-<html>
+<html lang="en">
    <head>
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       <title>Generate DASH Seed</title>
       <style>
          #topic_label {

--- a/public/sgl2020.html
+++ b/public/sgl2020.html
@@ -24,6 +24,7 @@
       </style>
    </head>
    <body>
+      <div id="wrapper">
       <div id="header">
          <a href="/"
             ><img
@@ -172,5 +173,6 @@
          >
       </div>
       <br />
+      </div>
    </body>
 </html>

--- a/public/sgl2020.html
+++ b/public/sgl2020.html
@@ -1,6 +1,7 @@
-<html>
+<html lang="en">
    <head>
       <title>DASH SG Live 2020 Tournament Edition</title>
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       <link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
       <link rel="stylesheet" type="text/css" href="dash.css" />
       <style>

--- a/public/sm_multi_tracker.html
+++ b/public/sm_multi_tracker.html
@@ -1,5 +1,6 @@
-<html>
+<html lang="en">
 <head>
+   <meta name="viewport" content="initial-scale=1.0, width=device-width" />
 <title>Super Metroid Multi-Category Tracker</title>
 
 <style>

--- a/public/tournament.html
+++ b/public/tournament.html
@@ -1,5 +1,6 @@
-<html>
+<html lang="en">
    <head>
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       <title>DASH Cash Tournament on SpeedGaming</title>
       <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
       <link rel="stylesheet" type="text/css" href="/dash.css" />

--- a/public/tournament.html
+++ b/public/tournament.html
@@ -5,6 +5,7 @@
       <link rel="stylesheet" type="text/css" href="/dash.css" />
    </head>
    <body>
+      <div id="wrapper">
       <div id="header">
          <a href="/"
             ><img
@@ -304,6 +305,7 @@
                <a href="https://discord.gg/rT2fWZt">SRL - Super Metroid</a>
             </li>
          </ul>
+      </div>
       </div>
    </body>
 </html>

--- a/public/updates.html
+++ b/public/updates.html
@@ -16,6 +16,7 @@
       </style>
    </head>
    <body>
+      <div id="wrapper">
       <div style="width: 770px; padding-left: 6px; padding-bottom: 12px">
          Along with adjusting the locations of items, it is common for Super
          Metroid randomizers to modify the original source code of the game to
@@ -153,5 +154,6 @@
             </td>
          </tr>
       </table>
+      </div>
    </body>
 </html>

--- a/public/updates.html
+++ b/public/updates.html
@@ -1,5 +1,6 @@
-<html>
+<html lang="en">
    <head>
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       <title>Game Updates in DASH</title>
       <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
       <link rel="stylesheet" type="text/css" href="/dash.css" />


### PR DESCRIPTION
This PR aims to make the site a bit more responsive and look better on mobile devices.

## Key Changes
1. The damage table has been redone in HTML. This scales down to mobile by stacking information vertically with its corresponding label instead of horizontally.
2. The site now uses its bold weight font. It was missing this before, which caused the browser to faux-bold certain pieces of text.
3. Specify the viewport as a `<meta>` tag so that the page can be sized on mobile devices appropriately.
4. Put a wrapper around the site for a max-width of 800px, which ensures 12-14 words per line to improve readability.