### PR TITLE
canAccessBotwoon check

### DIFF
--- a/scripts/lib/modes/modeRecall.js
+++ b/scripts/lib/modes/modeRecall.js
@@ -158,7 +158,7 @@ class ModeRecall {
             canAccessRedBrinstar(load) &&
             load.canUsePowerBombs &&
             (
-               (load.hasGravity && (load.hasIce || load.hasSpeed || load.hasSpazer)) ||
+               (load.hasGravity && (load.hasIce || load.hasSpeed)) ||
                (canDoSuitlessMaridia(load) && (load.hasIce || load.hasSpazer))
             )
          )

--- a/scripts/lib/modes/modeRecall.js
+++ b/scripts/lib/modes/modeRecall.js
@@ -158,7 +158,7 @@ class ModeRecall {
             canAccessRedBrinstar(load) &&
             load.canUsePowerBombs &&
             (
-               (load.hasGravity && (load.hasIce || load.hasSpeed)) ||
+               (load.hasGravity && (load.hasIce || load.hasSpeed || load.hasSpazer)) ||
                (canDoSuitlessMaridia(load) && (load.hasIce || load.hasSpazer))
             )
          )

--- a/scripts/lib/modes/modeRecall.js
+++ b/scripts/lib/modes/modeRecall.js
@@ -153,12 +153,21 @@ class ModeRecall {
          );
       };
 
-      const canDefeatBotwoon = (load) => {
+      const canAccessBotwoon = (load) => {
          return (
             canAccessRedBrinstar(load) &&
             load.canUsePowerBombs &&
-            (load.hasIce || load.hasSpeed || load.hasSpazer) &&
-            (load.hasGravity || (canDoSuitlessMaridia(load) && load.hasIce))
+            (
+               (load.hasGravity && (load.hasIce || load.hasSpeed || load.hasSpazer)) ||
+               (canDoSuitlessMaridia(load) && (load.hasIce || load.hasSpazer))
+            )
+         )
+      }
+
+      const canDefeatBotwoon = (load) => {
+         return (
+            canAccessBotwoon(load) &&
+            (load.superPacks > 2 || load.missilePacks > 4 || load.hasCharge)
          );
       };
 

--- a/scripts/lib/modes/modeRecall.js
+++ b/scripts/lib/modes/modeRecall.js
@@ -162,17 +162,10 @@ class ModeRecall {
                (canDoSuitlessMaridia(load) && (load.hasIce || load.hasSpazer))
             )
          )
-      }
-
-      const canDefeatBotwoon = (load) => {
-         return (
-            canAccessBotwoon(load) &&
-            (load.superPacks > 2 || load.missilePacks > 4 || load.hasCharge)
-         );
       };
 
       const canDefeatDraygon = (load) => {
-         return canDefeatBotwoon(load) && load.hasGravity;
+         return canAccessBotwoon(load) && load.hasGravity;
       };
 
       const canAccessWreckedShip = (load) => {
@@ -300,7 +293,7 @@ class ModeRecall {
       });
 
       major("Energy Tank (Botwoon)", (load) => {
-         return canDefeatBotwoon(load);
+         return canAccessBotwoon(load);
       });
 
       minor("Missiles (Aqueduct)", (load) => {

--- a/scripts/lib/modes/modeStandard.js
+++ b/scripts/lib/modes/modeStandard.js
@@ -136,17 +136,19 @@ class ModeStandard {
          );
       };
 
-      const canDefeatBotwoon = (load) => {
+      const canAccessBotwoon = (load) => {
          return (
             canAccessRedBrinstar(load) &&
             load.canUsePowerBombs &&
-            (load.hasIce || load.hasSpeed) &&
-            (load.hasGravity || (canDoSuitlessMaridia(load) && load.hasIce))
-         );
+            (
+               (load.hasGravity && (load.hasIce || load.hasSpeed || load.hasSpazer)) ||
+               (canDoSuitlessMaridia(load) && (load.hasIce || load.hasSpazer))
+            )
+         )
       };
 
       const canDefeatDraygon = (load) => {
-         return canDefeatBotwoon(load) && load.hasGravity;
+         return canAccessBotwoon(load) && load.hasGravity;
       };
 
       const canAccessWreckedShip = (load) => {
@@ -280,7 +282,7 @@ class ModeStandard {
       });
 
       major("Energy Tank (Botwoon)", (load) => {
-         return canDefeatBotwoon(load);
+         return canAccessBotwoon(load);
       });
 
       minor("Missiles (Aqueduct)", (load) => {

--- a/scripts/lib/modes/modeStandard.js
+++ b/scripts/lib/modes/modeStandard.js
@@ -141,7 +141,7 @@ class ModeStandard {
             canAccessRedBrinstar(load) &&
             load.canUsePowerBombs &&
             (
-               (load.hasGravity && (load.hasIce || load.hasSpeed || load.hasSpazer)) ||
+               (load.hasGravity && (load.hasIce || load.hasSpeed)) ||
                (canDoSuitlessMaridia(load) && (load.hasIce || load.hasSpazer))
             )
          )

--- a/scripts/lib/modes/modeStandard.js
+++ b/scripts/lib/modes/modeStandard.js
@@ -142,7 +142,7 @@ class ModeStandard {
             load.canUsePowerBombs &&
             (
                (load.hasGravity && (load.hasIce || load.hasSpeed)) ||
-               (canDoSuitlessMaridia(load) && (load.hasIce || load.hasSpazer))
+               (canDoSuitlessMaridia(load) && load.hasIce)
             )
          )
       };


### PR DESCRIPTION
Based off of a few discussions regarding `canDefeatBotwoon`, I've added a check for `canAccessBotwoon`. This check is simply to see if you can pass through the Botwoon hallway, suitless or otherwise.

I've also amended `canDefeatBotwoon` to include some ammo counts (not sure if relevant). We might want to consider just using `canAccessBotwoon` if we're only checking for access instead of testing the loadout for required ammo / items to defeat Botwoon.